### PR TITLE
Ship nff MCP ungated by default (auth opt-in via NFF_MCP_REQUIRE_AUTH)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,13 @@ It validates `Authorization: Bearer <token>` against the opaque MCP token
 only for liveness probing.) This gate is the whole reason the server is HTTP, not stdio:
 stdio can't gate the tools.
 
+**Disabling the gate (`NFF_MCP_NO_AUTH`):** set the env var `NFF_MCP_NO_AUTH=1` (also accepts
+`true`/`yes`/`on`) in the environment the server is launched from to bypass the Bearer check on
+`/mcp` entirely — no token, no OAuth handshake, no "needs authentication". Unset (the default)
+keeps the gate enforced. This is a single-knob, local-only opt-out for single-user benches; never
+set it on anything network-reachable, since it makes every tool callable without credentials.
+Implemented in both `bearer_auth` (Rust, `mcp_server.rs`) and `_NffASGI` (Python, `mcp_server.py`).
+
 **One-time bootstrap order:**
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,22 +51,24 @@ diagnosis tools carry their own token when they call the server.
 (default; override with `--host` / `--port`). All MCP messages — initialize, tools/list,
 tools/call — are HTTP POST requests to that path.
 
-### 3. Bearer authentication
+### 3. Bearer authentication (opt-in, OFF by default)
 
-Every request to `/mcp` is gated by the bearer check in `_NffASGI` (`nff/mcp_server.py`).
-It validates `Authorization: Bearer <token>` against the opaque MCP token
-(`config.mcp.access_token`) — or, for back-compat, the legacy `config.diagnosis.access_token`
-— in `~/.nff/config.json`. A missing or wrong token returns HTTP 401 and Claude surfaces an
-"Unauthorized" error for every tool call. (`/health` is the one unauthenticated route, used
-only for liveness probing.) This gate is the whole reason the server is HTTP, not stdio:
-stdio can't gate the tools.
+**The `/mcp` Bearer gate is OFF by default.** nff is a single-user, localhost-only bench tool,
+so out of the box `/mcp` is open: no token, no OAuth handshake, no "needs authentication". The
+server still binds to `127.0.0.1` only, so it is not network-reachable — but any local process
+can call the tools.
 
-**Disabling the gate (`NFF_MCP_NO_AUTH`):** set the env var `NFF_MCP_NO_AUTH=1` (also accepts
-`true`/`yes`/`on`) in the environment the server is launched from to bypass the Bearer check on
-`/mcp` entirely — no token, no OAuth handshake, no "needs authentication". Unset (the default)
-keeps the gate enforced. This is a single-knob, local-only opt-out for single-user benches; never
-set it on anything network-reachable, since it makes every tool callable without credentials.
-Implemented in both `bearer_auth` (Rust, `mcp_server.rs`) and `_NffASGI` (Python, `mcp_server.py`).
+**Requiring auth (`NFF_MCP_REQUIRE_AUTH`):** set `NFF_MCP_REQUIRE_AUTH=1` (also accepts
+`true`/`yes`/`on`) in the environment the server is launched from to turn the gate back ON. When
+set, every request to `/mcp` must carry `Authorization: Bearer <token>` validated against the
+opaque MCP token (`config.mcp.access_token`) — or, for back-compat, the legacy
+`config.diagnosis.access_token` — in `~/.nff/config.json`. A missing or wrong token then returns
+HTTP 401 and Claude surfaces an "Unauthorized" error, driving the OAuth browser login. (`/health`
+is always unauthenticated, used only for liveness probing.) Gating the tools is the reason the
+server is HTTP, not stdio: stdio can't gate them.
+
+Implemented in both `bearer_auth` (Rust, `mcp_server.rs`) and `_NffASGI` (Python, `mcp_server.py`);
+the server's advertised `instructions` string reflects whichever mode is active.
 
 **One-time bootstrap order:**
 

--- a/nff-rs/Cargo.lock
+++ b/nff-rs/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "nff"
-version = "0.2.29"
+version = "0.2.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/nff-rs/nff/src/mcp_server.rs
+++ b/nff-rs/nff/src/mcp_server.rs
@@ -245,24 +245,25 @@ fn parse_query(q: &Option<String>) -> HashMap<String, String> {
     map
 }
 
-/// True when the operator has explicitly disabled the `/mcp` Bearer gate via the
-/// `NFF_MCP_NO_AUTH` env var (accepts `1`/`true`/`yes`/`on`, case-insensitive).
-/// Default (unset) keeps the gate enforced — opting out is a deliberate, local-only act.
-fn auth_disabled() -> bool {
-    std::env::var("NFF_MCP_NO_AUTH")
+/// True only when the operator has explicitly opted **into** the `/mcp` Bearer gate
+/// via the `NFF_MCP_REQUIRE_AUTH` env var (accepts `1`/`true`/`yes`/`on`, case-insensitive).
+/// Default (unset) leaves the gate OFF — nff ships ungated for the single-user, localhost-only
+/// bench model; enabling auth is the deliberate, opt-in act.
+fn auth_required() -> bool {
+    std::env::var("NFF_MCP_REQUIRE_AUTH")
         .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
         .unwrap_or(false)
 }
 
 /// Bearer guard on `/mcp`: accept the opaque MCP access token OR (legacy) the raw
 /// diagnosis JWT, so sessions authorized before opaque tokens existed keep working.
-/// Short-circuits to open access when `NFF_MCP_NO_AUTH` is set (see `auth_disabled`).
+/// Open by default; only enforced when `NFF_MCP_REQUIRE_AUTH` is set (see `auth_required`).
 async fn bearer_auth(
     State(oauth): State<Arc<OAuthState>>,
     request: axum::extract::Request,
     next: Next,
 ) -> Response {
-    if auth_disabled() {
+    if !auth_required() {
         return next.run(request).await;
     }
     let presented = request
@@ -857,11 +858,14 @@ impl ServerHandler for NffServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("nff", env!("CARGO_PKG_VERSION")))
-            .with_instructions(
-                "nff MCP server — all tools require HTTP Bearer authentication. \
-                Use `nff auth login` to obtain a token, then pass it as \
-                Authorization: Bearer <token> on every request.",
-            )
+            .with_instructions(if auth_required() {
+                "nff MCP server — the /mcp endpoint requires HTTP Bearer authentication \
+                (NFF_MCP_REQUIRE_AUTH is set). Use `nff auth login` to obtain a token, then \
+                pass it as Authorization: Bearer <token> on every request."
+            } else {
+                "nff MCP server — local bench tools, open by default (no authentication). \
+                Set NFF_MCP_REQUIRE_AUTH=1 to require an HTTP Bearer token on /mcp."
+            })
     }
 }
 

--- a/nff-rs/nff/src/mcp_server.rs
+++ b/nff-rs/nff/src/mcp_server.rs
@@ -245,13 +245,26 @@ fn parse_query(q: &Option<String>) -> HashMap<String, String> {
     map
 }
 
+/// True when the operator has explicitly disabled the `/mcp` Bearer gate via the
+/// `NFF_MCP_NO_AUTH` env var (accepts `1`/`true`/`yes`/`on`, case-insensitive).
+/// Default (unset) keeps the gate enforced — opting out is a deliberate, local-only act.
+fn auth_disabled() -> bool {
+    std::env::var("NFF_MCP_NO_AUTH")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
 /// Bearer guard on `/mcp`: accept the opaque MCP access token OR (legacy) the raw
 /// diagnosis JWT, so sessions authorized before opaque tokens existed keep working.
+/// Short-circuits to open access when `NFF_MCP_NO_AUTH` is set (see `auth_disabled`).
 async fn bearer_auth(
     State(oauth): State<Arc<OAuthState>>,
     request: axum::extract::Request,
     next: Next,
 ) -> Response {
+    if auth_disabled() {
+        return next.run(request).await;
+    }
     let presented = request
         .headers()
         .get(header::AUTHORIZATION)

--- a/nff-rs/nff/tests/mcp.rs
+++ b/nff-rs/nff/tests/mcp.rs
@@ -52,20 +52,36 @@ struct Server {
 }
 
 impl Server {
+    /// Default server — the `/mcp` Bearer gate is OFF (nff ships ungated).
     fn start() -> Server {
+        Server::start_inner(false)
+    }
+
+    /// Server with the Bearer gate enforced via `NFF_MCP_REQUIRE_AUTH=1`. The env var is
+    /// set only on this child process, so it can't leak into other (parallel) tests.
+    fn start_with_auth() -> Server {
+        Server::start_inner(true)
+    }
+
+    fn start_inner(require_auth: bool) -> Server {
         let port = free_port();
         let base = format!("http://127.0.0.1:{port}");
-        let child = Command::new(nff())
-            .arg("mcp")
+        let mut cmd = Command::new(nff());
+        cmd.arg("mcp")
             .arg("--host")
             .arg("127.0.0.1")
             .arg("--port")
             .arg(port.to_string())
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("failed to spawn nff mcp");
+            .stderr(Stdio::null());
+        if require_auth {
+            cmd.env("NFF_MCP_REQUIRE_AUTH", "1");
+        } else {
+            // Make the child immune to a require-auth value inherited from the caller's env.
+            cmd.env_remove("NFF_MCP_REQUIRE_AUTH");
+        }
+        let child = cmd.spawn().expect("failed to spawn nff mcp");
         let server = Server { child, base };
         server.wait_until_ready();
         server
@@ -169,8 +185,28 @@ fn oauth_register_returns_static_client() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn mcp_requires_bearer_auth() {
+fn mcp_open_by_default() {
+    // With no NFF_MCP_REQUIRE_AUTH, the gate is off: an unauthenticated initialize
+    // must NOT be rejected with 401 (it reaches the MCP handler instead).
     let server = Server::start();
+    let resp = client()
+        .post(server.url("/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(INIT_BODY)
+        .send()
+        .expect("request failed");
+    assert_ne!(
+        resp.status().as_u16(),
+        401,
+        "gate is off by default — unauthenticated /mcp must not be rejected, got {}",
+        resp.status()
+    );
+}
+
+#[test]
+fn mcp_requires_bearer_auth() {
+    let server = Server::start_with_auth();
     let resp = client()
         .post(server.url("/mcp"))
         .header("content-type", "application/json")
@@ -196,7 +232,7 @@ fn mcp_requires_bearer_auth() {
 
 #[test]
 fn mcp_rejects_unknown_bearer_token() {
-    let server = Server::start();
+    let server = Server::start_with_auth();
     let resp = client()
         .post(server.url("/mcp"))
         .header("content-type", "application/json")

--- a/nff/mcp_server.py
+++ b/nff/mcp_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 import secrets
 from collections.abc import AsyncIterator
 from typing import Any, Optional
@@ -25,6 +26,15 @@ from nff import config
 # ---------------------------------------------------------------------------
 # Resolver helpers (tested directly)
 # ---------------------------------------------------------------------------
+
+
+def _auth_disabled() -> bool:
+    """True when `NFF_MCP_NO_AUTH` (1/true/yes/on) turns off the /mcp Bearer gate.
+
+    Default (unset) keeps the gate enforced — disabling it is a deliberate,
+    local-only opt-out so the "needs authentication" handshake goes away.
+    """
+    return os.environ.get("NFF_MCP_NO_AUTH", "").strip().lower() in ("1", "true", "yes", "on")
 
 
 def _resolve_port(port: Optional[str]) -> str:
@@ -553,17 +563,21 @@ class _NffASGI:
             elif path.startswith("/.well-known/") or path.startswith("/oauth/"):
                 await self._handle_oauth_route(path, scope, receive, send)
             elif path == "/mcp" or path.startswith("/mcp/"):
-                headers_dict = dict(scope.get("headers", []))
-                auth = headers_dict.get(b"authorization", b"").decode()
-                presented = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
-                mcp_token = config.get_mcp_tokens().get("access_token")
-                # Legacy: sessions authorized before opaque tokens existed still hold
-                # the raw Supabase JWT. Accept it once so the live session isn't broken;
-                # Claude re-authorizes on its next expiry and upgrades to an MCP token.
-                legacy_token = config.get_diagnosis_config().get("access_token")
-                if not presented or presented not in (mcp_token, legacy_token):
-                    await self._send_401(send)
-                    return
+                # `NFF_MCP_NO_AUTH` (1/true/yes/on) disables the Bearer gate entirely —
+                # one env-var knob for local, single-user setups that don't want the
+                # "needs authentication" handshake. Default keeps the gate enforced.
+                if not _auth_disabled():
+                    headers_dict = dict(scope.get("headers", []))
+                    auth = headers_dict.get(b"authorization", b"").decode()
+                    presented = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
+                    mcp_token = config.get_mcp_tokens().get("access_token")
+                    # Legacy: sessions authorized before opaque tokens existed still hold
+                    # the raw Supabase JWT. Accept it once so the live session isn't broken;
+                    # Claude re-authorizes on its next expiry and upgrades to an MCP token.
+                    legacy_token = config.get_diagnosis_config().get("access_token")
+                    if not presented or presented not in (mcp_token, legacy_token):
+                        await self._send_401(send)
+                        return
                 await self._sm.handle_request(scope, receive, send)
             else:
                 await self._send_404(send)

--- a/nff/mcp_server.py
+++ b/nff/mcp_server.py
@@ -28,13 +28,14 @@ from nff import config
 # ---------------------------------------------------------------------------
 
 
-def _auth_disabled() -> bool:
-    """True when `NFF_MCP_NO_AUTH` (1/true/yes/on) turns off the /mcp Bearer gate.
+def _auth_required() -> bool:
+    """True only when `NFF_MCP_REQUIRE_AUTH` (1/true/yes/on) opts into the /mcp Bearer gate.
 
-    Default (unset) keeps the gate enforced — disabling it is a deliberate,
-    local-only opt-out so the "needs authentication" handshake goes away.
+    Default (unset) leaves the gate OFF — nff ships ungated for the single-user,
+    localhost-only bench, so there is no "needs authentication" handshake unless you
+    explicitly ask for one.
     """
-    return os.environ.get("NFF_MCP_NO_AUTH", "").strip().lower() in ("1", "true", "yes", "on")
+    return os.environ.get("NFF_MCP_REQUIRE_AUTH", "").strip().lower() in ("1", "true", "yes", "on")
 
 
 def _resolve_port(port: Optional[str]) -> str:
@@ -563,10 +564,10 @@ class _NffASGI:
             elif path.startswith("/.well-known/") or path.startswith("/oauth/"):
                 await self._handle_oauth_route(path, scope, receive, send)
             elif path == "/mcp" or path.startswith("/mcp/"):
-                # `NFF_MCP_NO_AUTH` (1/true/yes/on) disables the Bearer gate entirely —
-                # one env-var knob for local, single-user setups that don't want the
-                # "needs authentication" handshake. Default keeps the gate enforced.
-                if not _auth_disabled():
+                # The /mcp Bearer gate is OFF by default (single-user, localhost-only
+                # bench). Set `NFF_MCP_REQUIRE_AUTH` (1/true/yes/on) to opt into the
+                # "needs authentication" handshake.
+                if _auth_required():
                     headers_dict = dict(scope.get("headers", []))
                     auth = headers_dict.get(b"authorization", b"").decode()
                     presented = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -88,6 +88,13 @@ def base_url(mcp_url: str) -> str:
     return mcp_url[: -len("/mcp")]
 
 
+@pytest.fixture(autouse=True)
+def _gate_off_by_default(monkeypatch):
+    """nff ships ungated. Clear any stray NFF_MCP_REQUIRE_AUTH so the suite's default
+    matches shipped behavior (gate OFF); tests that need the gate set it explicitly."""
+    monkeypatch.delenv("NFF_MCP_REQUIRE_AUTH", raising=False)
+
+
 # ===========================================================================
 # UNIT TESTS — resolver helpers (no transport)
 # ===========================================================================
@@ -287,16 +294,25 @@ _ALL_TOOL_NAMES = {
 # Bearer auth gate — HTTP transport level
 # ---------------------------------------------------------------------------
 
-async def test_mcp_transport_returns_401_without_token(base_url):
-    """POST to /mcp without Authorization header returns 401 when no token stored."""
+async def test_mcp_transport_returns_401_without_token(base_url, monkeypatch):
+    """With NFF_MCP_REQUIRE_AUTH on, POST to /mcp without a token returns 401."""
+    monkeypatch.setenv("NFF_MCP_REQUIRE_AUTH", "1")
     async with httpx.AsyncClient() as client:
         resp = await client.post(f"{base_url}/mcp", content=b"{}")
     assert resp.status_code == 401
     assert "www-authenticate" in resp.headers
 
 
-async def test_mcp_transport_returns_401_with_wrong_token(base_url):
-    """POST to /mcp with wrong Bearer token returns 401."""
+async def test_mcp_transport_open_without_auth_by_default(base_url):
+    """Gate is OFF by default: an unauthenticated /mcp POST is NOT rejected with 401."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{base_url}/mcp", content=b"{}")
+    assert resp.status_code != 401
+
+
+async def test_mcp_transport_returns_401_with_wrong_token(base_url, monkeypatch):
+    """With NFF_MCP_REQUIRE_AUTH on, POST to /mcp with a wrong token returns 401."""
+    monkeypatch.setenv("NFF_MCP_REQUIRE_AUTH", "1")
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             f"{base_url}/mcp",


### PR DESCRIPTION
## Summary
Inverts the `/mcp` Bearer gate so nff ships **ungated by default**, matching its single-user, localhost-only bench model. Authentication is now **opt-in**.

- **Gate OFF by default** — `/mcp` is open out of the box: no token, no OAuth handshake, no "needs authentication".
- **Opt back in** with `NFF_MCP_REQUIRE_AUTH=1` (also `true`/`yes`/`on`), which restores the prior Bearer-gated + OAuth-login behavior. Replaces the earlier `NFF_MCP_NO_AUTH` opt-out.
- The server's advertised `instructions` string now reflects whichever mode is active (no more stale "auth required" claim).
- Server still binds to `127.0.0.1` only, so it is not network-reachable — but any local process can call the tools when the gate is off.

Landed in both implementations (CLAUDE.md requires parity):
- Rust (shipped): `bearer_auth` in `nff-rs/nff/src/mcp_server.rs`
- Python (reference): `_NffASGI` in `nff/mcp_server.py`
- Docs: Bearer-auth section of `nff/CLAUDE.md`

## Tests
- **Rust:** 81 unit + 6 integration pass (new `mcp_open_by_default`; the two 401 tests now run through a `start_with_auth()` child that sets `NFF_MCP_REQUIRE_AUTH`). `cargo clippy --all-targets` clean.
- **Python:** auth tests pass, incl. new `test_mcp_transport_open_without_auth_by_default` + an autouse fixture clearing the env so the default is OFF; the 401 tests opt in via `monkeypatch`. (Two unrelated `flash` test failures are the known nff-sdk-c stale-sync warning, not auth.)
- **Live:** verified an unauthenticated MCP `initialize` returns 200 with no `Authorization` header.

## ⚠️ Release impact
Merging to `main` triggers the auto-release pipeline (version bump + publish to public PyPI + GitHub Release). After merge, **every `pip install nff` becomes open-by-default**. Intended and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)